### PR TITLE
simplify timer. simplify log replication and follower commit

### DIFF
--- a/pkg/kvstore/kvstorerpcserver.go
+++ b/pkg/kvstore/kvstorerpcserver.go
@@ -15,13 +15,13 @@ import (
 // RPCServer is used to implement pb.KVStoreRPCServer
 type RPCServer struct {
 	wg     sync.WaitGroup
-	node   raft.INode
+	node   raft.INodeRPCProvider
 	server *grpc.Server
 	pb.UnimplementedKVStoreRaftServer
 }
 
 // NewServer creates a new RPC server
-func NewServer(node raft.INode) *RPCServer {
+func NewServer(node raft.INodeRPCProvider) *RPCServer {
 	return &RPCServer{
 		node: node,
 	}

--- a/pkg/raft/logmgr_test.go
+++ b/pkg/raft/logmgr_test.go
@@ -234,30 +234,44 @@ func TestFindFirstConflictingEntryIndex(t *testing.T) {
 
 	// no conflict and all are new entries
 	e := generateTestEntries(4, 5)
-	ret := lm.findFirstConflictingEntryIndex(e)
+	ret := lm.findFirstConflictIndex(4, e)
 	if ret != e[0].Index || ret != lm.lastIndex+1 {
 		t.Error("findFirstConflictingEntryIndex wrong index returned when all incoming data are new and no conflict")
 	}
 
 	// one conflicting entries
 	e = generateTestEntries(3, 6)
-	ret = lm.findFirstConflictingEntryIndex(e)
+	ret = lm.findFirstConflictIndex(3, e)
 	if ret != 4 {
 		t.Error("findFirstConflictingEntryIndex returns wrong index when there is one conflicting entry")
 	}
 
 	// all entries conflict
 	e = generateTestEntries(2, 6)
-	ret = lm.findFirstConflictingEntryIndex(e)
+	ret = lm.findFirstConflictIndex(2, e)
 	if ret != e[0].Index {
 		t.Error("findFirstConflictingEntryIndex returns wrong index when all entries conflict")
 	}
 
 	// all match (duplicate), should return lm.lastIndex + 1
 	e = lm.logs[3:]
-	ret = lm.findFirstConflictingEntryIndex(e)
+	ret = lm.findFirstConflictIndex(2, e)
 	if ret != lm.lastIndex+1 {
-		t.Error("findFirstConflictingEntryIndex returns wrong index when all entries conflict")
+		t.Error("findFirstConflictingEntryIndex returns wrong index when all entries match")
+	}
+
+	// empty entries with matching prev index
+	e = []LogEntry{}
+	ret = lm.findFirstConflictIndex(3, e)
+	if ret != 4 {
+		t.Error("findFirstConflictingEntryIndex returns wrong index upon heartbeat")
+	}
+
+	// empty entries with non matching prev index (-1)
+	e = []LogEntry{}
+	ret = lm.findFirstConflictIndex(-1, e)
+	if ret != 0 {
+		t.Error("findFirstConflictingEntryIndex returns wrong index upon heartbeat")
 	}
 }
 

--- a/pkg/raft/rafttimer.go
+++ b/pkg/raft/rafttimer.go
@@ -21,66 +21,77 @@ type IRaftTimer interface {
 }
 
 type raftTimer struct {
-	node  INode
-	wg    *sync.WaitGroup
-	state chan NodeState
-	timer *time.Timer
+	wg       *sync.WaitGroup
+	timer    *time.Timer
+	callback func()
 }
 
-func newRaftTimer(node INode) IRaftTimer {
+// NewRaftTimer creates a new raft timer
+func NewRaftTimer(timerCallback func()) IRaftTimer {
 	return &raftTimer{
-		node:  node,
-		wg:    &sync.WaitGroup{},
-		state: make(chan NodeState, 10),
-		timer: nil, // only initialized upon start
+		wg:       &sync.WaitGroup{},
+		callback: timerCallback,
 	}
+}
+
+// Start starts the timer with follower state
+func (rt *raftTimer) Start() {
+	if rt.timer != nil {
+		util.Panicln("Timer is already started")
+	}
+
+	// Use a longer initial timeout since establishing RPC connection takes time during startup
+	// Think about this scenario when one node failed:
+	// t0: leader sends heartbeat, it fails to send to the failed node (we don't retry here, unlike the paper)
+	// t1: the failed node recovers right after t0, and sets election timer
+	// t2: leader sends new heartbeat, it'll arrive at the recovered node, but takes time (timeout + RPC connection and processing time)
+	// t3: recovered node processes the new heartbeat and follows leader term, and its election timer fires at the same time
+	// t4: recovered node starts new election with higher term, but it never wins due to stale log
+	// t5: original leader gets reset to follower due to the higher term and starts another election since recovered node is not getting elected
+	// t6: recovered node starts another election due to failed vote
+	// t7: repeating t4-t5 and we might have a temporary election storm
+	// This is due to we never block on RPC calls. So we are adding the extra delay during startup to prevent this.
+	rt.timer = time.NewTimer(rt.getElectionTimeout() + 2*time.Second)
+
+	// Start timer event loop
+	rt.wg.Add(1)
+	go rt.eventLoop()
+}
+
+// refreshRaftTimer refreshes the timer based on node state and tries to drain pending timer events if any
+func (rt *raftTimer) Refresh(newState NodeState) {
+	if newState == Leader {
+		util.ResetTimer(rt.timer, heartbeatTimeout)
+	} else {
+		util.ResetTimer(rt.timer, rt.getElectionTimeout())
+	}
+}
+
+// stopRaftTimer stops the raft timer goroutine
+func (rt *raftTimer) Stop() {
+	util.StopTimer(rt.timer)
+	rt.wg.Wait()
+	rt.timer = nil
+}
+
+// timer event loop
+func (rt *raftTimer) eventLoop() {
+	stop := false
+	for !stop {
+		select {
+		case _, ok := <-rt.timer.C:
+			if !ok {
+				stop = true
+			} else {
+				rt.callback()
+			}
+		}
+	}
+	rt.wg.Done()
 }
 
 // getElectionTimeout gets a random election timeout
 func (rt *raftTimer) getElectionTimeout() time.Duration {
 	timeoutMS := rand.Intn(maxElectionTimeoutMS-minElectionTimeoutMS) + minElectionTimeoutMS
 	return time.Duration(timeoutMS) * time.Millisecond
-}
-
-func (rt *raftTimer) Start() {
-	if rt.timer != nil {
-		util.Panicln("Timer is already started")
-	}
-
-	rt.timer = time.NewTimer(rt.getElectionTimeout())
-
-	rt.wg.Add(1)
-	go func() {
-		stop := false
-		for !stop {
-			select {
-			case state := <-rt.state:
-				if state == Follower || state == Candidate {
-					// reset timer on follower/candidate state with random election timeout
-					util.ResetTimer(rt.timer, rt.getElectionTimeout())
-				} else if state == Leader {
-					// reset timer with hearbeat timeout for leader state
-					util.ResetTimer(rt.timer, heartbeatTimeout)
-				} else {
-					stop = true
-				}
-			case <-rt.timer.C:
-				// tell node that we need a new election or heatbeat
-				rt.node.OnTimer()
-			}
-		}
-		rt.wg.Done()
-	}()
-}
-
-// refreshRaftTimer notifies the timer to refresh based on new state
-func (rt *raftTimer) Refresh(newState NodeState) {
-	rt.state <- newState
-}
-
-// stopRaftTimer stops the raft timer goroutine
-func (rt *raftTimer) Stop() {
-	rt.state <- -1
-	rt.wg.Wait()
-	rt.timer = nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,10 +6,9 @@ import "time"
 func StopTimer(timer *time.Timer) {
 	if !timer.Stop() {
 		// The Timer document is inaccurate with a bad exmaple - timer.Stop returning false doesn't necessarily
-		// mean there is anything to drain in the channel. Blind draining can cause dead locking
+		// mean there is anything to drain in the channel. Blindly draining can block.
 		// e.g. Stop is called after event is already fired. In this case draining the channel will block.
-		// We use a default clause here to stop us from blocking - the current go routine is the sole reader of the timer channel
-		// so no synchronization is required
+		// We use a default clause here to prevent this.
 		select {
 		case <-timer.C:
 		default:


### PR DESCRIPTION
simplify timer - getting rid of the channel, it's not necessary
simplify log replication and follower commit - now we process heartbeat and real AE request in the same way. Also fixed a bug in the commit logic upon heartbeat where we incorrectly assumed all local logs match and commit (we didn't do proper log truncation upon heartbeat)