### PR TITLE
Enable "blocked" replication and consensus checking upon execution

### DIFF
--- a/cmd/rkv/main.go
+++ b/cmd/rkv/main.go
@@ -45,10 +45,10 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Println("rkv -nodeid id -addresses node0address,node1address,node2addresses... -loglevel 1-4")
+	fmt.Println("rkv -nodeid id -addresses node0address:port,node1address:port,node2addresses:port... -loglevel level")
 	fmt.Println("   -id: 0 based current node ID, indexed into addresses to get local port")
 	fmt.Println("   -addresses: comma separated server:port for all nodes")
-	fmt.Println("   -loglevel: number 1-4 (1 - error, 2 - warning, 3 - info, 4 - traces), default 3")
+	fmt.Println("   -loglevel: number 1-4 (1 - error, 2 - warning, 3 - info, 4 - traces, 5 - verbose), default 3")
 }
 
 func runRPC(nodeID int, port string, addresses []string) {

--- a/cmd/rkvclient/main.go
+++ b/cmd/rkvclient/main.go
@@ -85,11 +85,13 @@ func benchmark(ctx context.Context, client pb.KVStoreRaftClient, times int) {
 	for i := 0; i < times; i++ {
 		wg.Add(1)
 		go func(i int) {
-			_, err := client.Set(ctx, &pb.SetRequest{Key: fmt.Sprintf("k%d", i), Value: fmt.Sprint(i)})
-			if err == nil {
+			r, err := client.Set(ctx, &pb.SetRequest{Key: fmt.Sprintf("k%d", i), Value: fmt.Sprint(i)})
+			if err == nil && r.Success {
 				successCount++
-			} else {
+			} else if err != nil {
 				fmt.Println(err)
+			} else {
+				fmt.Println("Leader processes but failed to commit in time")
 			}
 			wg.Done()
 		}(i)

--- a/cmd/rkvclient/main.go
+++ b/cmd/rkvclient/main.go
@@ -89,9 +89,9 @@ func benchmark(ctx context.Context, client pb.KVStoreRaftClient, times int) {
 			if err == nil && r.Success {
 				successCount++
 			} else if err != nil {
-				fmt.Println(err)
+				// fmt.Println(err)
 			} else {
-				fmt.Println("Leader processes but failed to commit in time")
+				// fmt.Println("Leader processed but failed to commit in time")
 			}
 			wg.Done()
 		}(i)

--- a/pkg/kvstore/kvstorepeerclient.go
+++ b/pkg/kvstore/kvstorepeerclient.go
@@ -24,6 +24,7 @@ var errorInvalidExecuteRequest = errors.New("Execute request is neither Set nor 
 
 // KVPeerClient defines the proxy used by kv store, implementing IPeerProxyFactory and IPeerProxy
 type KVPeerClient struct {
+	raft.NodeInfo
 	client pb.KVStoreRaftClient
 }
 
@@ -41,58 +42,73 @@ func (proxy *KVPeerClient) NewPeerProxy(info raft.NodeInfo) raft.IPeerProxy {
 	client := pb.NewKVStoreRaftClient(conn)
 
 	return &KVPeerClient{
+		NodeInfo: raft.NodeInfo{
+			NodeID:   info.NodeID,
+			Endpoint: info.Endpoint,
+		},
 		client: client,
 	}
 }
 
 // AppendEntries sends AE request to one single node
-func (proxy *KVPeerClient) AppendEntries(req *raft.AppendEntriesRequest, callback func(*raft.AppendEntriesReply)) {
+func (proxy *KVPeerClient) AppendEntries(req *raft.AppendEntriesRequest, onReply func(*raft.AppendEntriesReply)) {
 	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeOut)
 	defer cancel()
 
+	// Makesure onReply is called regardless of what happens
+	// Note we cannot use "defer onReply(reply)" directly since param evaluation happens when defer is called and it will be nil
+	// Here we use a closure to make sure latest value of reply is used
 	var reply *raft.AppendEntriesReply
+	defer func() { onReply(reply) }()
+
 	ae := fromRaftAERequest(req)
 	if resp, err := proxy.client.AppendEntries(ctx, ae); err != nil {
-		//util.WriteError("Error sending AppendEntries message. %s", err)
+		util.WriteTrace("Error sending AppendEntries message to Node%d. %s", proxy.NodeID, err)
 	} else {
 		reply = toRaftAEReply(resp)
 	}
-
-	callback(reply)
 }
 
 // RequestVote handles raft RPC RV calls to a given node
-func (proxy *KVPeerClient) RequestVote(req *raft.RequestVoteRequest, callback func(*raft.RequestVoteReply)) {
+func (proxy *KVPeerClient) RequestVote(req *raft.RequestVoteRequest, onReply func(*raft.RequestVoteReply)) {
 	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeOut)
 	defer cancel()
 
+	// Makesure onReply is called regardless of what happens
+	// Note we cannot use "defer onReply(reply)" directly since param evaluation happens when defer is called and it will be nil
+	// Here we use a closure to make sure latest value of reply is used
 	var reply *raft.RequestVoteReply
+	defer func() { onReply(reply) }()
+
 	rv := fromRaftRVRequest(req)
 	if resp, err := proxy.client.RequestVote(ctx, rv); err != nil {
-		//util.WriteError("Error sending RequestVote message. %s", err)
+		util.WriteTrace("Error sending RequestVote messageto Node%d. %s", proxy.NodeID, err)
 	} else {
 		reply = toRaftRVReply(resp)
 	}
-
-	callback(reply)
 }
 
 // InstallSnapshot takes snapshot request (with snapshotfile) and send it to the remote peer
-func (proxy *KVPeerClient) InstallSnapshot(req *raft.SnapshotRequest, callback func(*raft.AppendEntriesReply)) {
+// onReply is gauranteed to be called
+func (proxy *KVPeerClient) InstallSnapshot(req *raft.SnapshotRequest, onReply func(*raft.AppendEntriesReply)) {
 	ctx, cancel := context.WithTimeout(context.Background(), snapshotRPCTimeout)
 	defer cancel()
 
+	// Makesure onReply is called regardless of what happens
+	// Note we cannot use "defer onReply(reply)" directly since param evaluation happens when defer is called and it will be nil
+	// Here we use a closure to make sure latest value of reply is used
+	var reply *raft.AppendEntriesReply
+	defer func() { onReply(reply) }()
+
 	stream, err := proxy.client.InstallSnapshot(ctx)
 	if err != nil {
-		//util.WriteError("Error opening gRPC snapshot stream. %s", err)
-		callback(nil)
+		util.WriteTrace("Error opening gRPC snapshot stream with Node%d. %s", proxy.NodeID, err)
 		return
 	}
 
 	reader, err := raft.ReadSnapshot(req.File)
 	if err != nil {
 		util.WriteError("Error opening snapshot file. %s", err)
-		callback(nil)
 		return
 	}
 
@@ -100,19 +116,16 @@ func (proxy *KVPeerClient) InstallSnapshot(req *raft.SnapshotRequest, callback f
 	writer := newGRPCSnapshotStreamWriter(req, stream)
 	if _, err := io.Copy(writer, reader); err != nil {
 		util.WriteError("Error sending snapshot. %s", err)
-		callback(nil)
 		return
 	}
 
 	resp, err := stream.CloseAndRecv()
 	if err != nil {
 		util.WriteError("Error waiting for snapshot reply. %s", err)
-		callback(nil)
 		return
 	}
 
-	reply := toRaftAEReply(resp)
-	callback(reply)
+	reply = toRaftAEReply(resp)
 }
 
 // Get gets values from state machine against leader

--- a/pkg/kvstore/kvstorerpcserver.go
+++ b/pkg/kvstore/kvstorerpcserver.go
@@ -52,7 +52,9 @@ func (s *RPCServer) RequestVote(ctx context.Context, req *pb.RequestVoteRequest)
 	return fromRaftRVReply(resp), nil
 }
 
-// InstallSnapshot installs snapshot on the target node
+// InstallSnapshot installs snapshot on current node
+// TODO[sidecus]: This keeps the reading loop out of raft and it has no idea of chunk reception (and hence no response on each chunk).
+// If the snapshot is big it might cause resending from leader
 func (s *RPCServer) InstallSnapshot(stream pb.KVStoreRaft_InstallSnapshotServer) error {
 	// create snapshot reader
 	reader, err := newGRPCSnapshotStreamReader(stream)

--- a/pkg/raft/logmgr.go
+++ b/pkg/raft/logmgr.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sidecus/raft/pkg/util"
 )
 
-const snapshotEntriesCount = 10
+const snapshotEntriesCount = 2000
 
 // LogEntry - one raft log entry, with term and index
 type LogEntry struct {
@@ -115,6 +115,7 @@ func (lm *LogManager) GetLogEntry(index int) LogEntry {
 
 // GetLogEntries returns entries between [start, end).
 // Same behavior as normal slicing but with index shiftted according to snapshotIndex.
+// Additonaly, it adds end boundary protection if it's out of range
 // It also returns the prevIndex/prevTerm
 func (lm *LogManager) GetLogEntries(start int, end int) (entries []LogEntry, prevIndex int, prevTerm int) {
 	if start <= lm.snapshotIndex {

--- a/pkg/raft/logmgr.go
+++ b/pkg/raft/logmgr.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sidecus/raft/pkg/util"
 )
 
-const snapshotEntriesCount = 1000
+const snapshotEntriesCount = 10
 
 // LogEntry - one raft log entry, with term and index
 type LogEntry struct {
@@ -26,7 +26,7 @@ type ILogManager interface {
 
 	ProcessCmd(cmd StateMachineCmd, term int)
 	ProcessLogs(prevLogIndex, prevLogTerm int, entries []LogEntry) (prevMatch bool)
-	Commit(targetIndex int) (newCommit bool, newSnapshot bool)
+	CommitAndApply(targetIndex int) (newCommit bool, newSnapshot bool)
 	InstallSnapshot(snapshotFile string, snapshotIndex int, snapshotTerm int) error
 
 	// proxy to state machine
@@ -159,7 +159,7 @@ func (lm *LogManager) ProcessLogs(prevLogIndex, prevLogTerm int, entries []LogEn
 	lm.validateLogEntries(prevLogIndex, prevLogTerm, entries)
 
 	prevMatch := lm.hasMatchingPrevEntry(prevLogIndex, prevLogTerm)
-	util.WriteTrace("Match on prevIndex(%d) prevTerm(%d): %v", prevLogIndex, prevLogTerm, prevMatch)
+	util.WriteVerbose("Match on prevIndex(%d) prevTerm(%d): %v", prevLogIndex, prevLogTerm, prevMatch)
 	if !prevMatch {
 		return false
 	}
@@ -176,31 +176,31 @@ func (lm *LogManager) ProcessLogs(prevLogIndex, prevLogTerm int, entries []LogEn
 	return true
 }
 
-// Commit tries to logs up to the target index
+// CommitAndApply commits logs up to the target index and applies it to state machine
 // returns true if anything is committed
-func (lm *LogManager) Commit(targetIndex int) (newCommit bool, newSnapshot bool) {
-	// cap to lastIndex
-	targetIndex = util.Min(targetIndex, lm.lastIndex)
+func (lm *LogManager) CommitAndApply(targetIndex int) (newCommit bool, newSnapshot bool) {
+	if targetIndex > lm.lastIndex {
+		util.Panicln("Cannot commit to a value larger than last index")
+	}
 	if targetIndex <= lm.commitIndex {
-		// nothing to commit
-		return
+		return // nothing to commit
 	}
 
 	newCommit = true
 
 	// Set new commit index and apply commands to state machine if needed
 	lm.commitIndex = targetIndex
-	if targetIndex > lm.lastApplied {
-		for i := lm.lastApplied + 1; i <= targetIndex; i++ {
+	if lm.commitIndex > lm.lastApplied {
+		for i := lm.lastApplied + 1; i <= lm.commitIndex; i++ {
 			lm.statemachine.Apply(lm.GetLogEntry(i).Cmd)
 		}
-		lm.lastApplied = targetIndex
+		lm.lastApplied = lm.commitIndex
 	}
 
 	// take snapshot if needed
 	if lm.lastApplied-lm.snapshotIndex >= snapshotEntriesCount {
 		if err := lm.TakeSnapshot(); err != nil {
-			util.WriteError("Snapshot failure: %s", err)
+			util.WriteError("Failed to take snapshot: %s", err)
 		} else {
 			newSnapshot = true
 		}

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -276,7 +276,7 @@ func TestReplicateToFollower(t *testing.T) {
 	// nextIndex is larger than lastIndex, nothing to replicate
 	peer0.nextIndex = logMgr.lastIndex + 1
 	peer0.matchIndex = 1
-	ret := n.replicateToFollower(0)
+	ret := n.replicateToFollower(0, n.onHeartbeatReply)
 	if ret {
 		t.Error("replicateLogsTo should not replicate when nextIndex is high enough")
 	}
@@ -284,7 +284,7 @@ func TestReplicateToFollower(t *testing.T) {
 	// nextIndex is smaler than lastIndex
 	peer0.nextIndex = 2
 	peer0.matchIndex = 1
-	ret = n.replicateToFollower(0)
+	ret = n.replicateToFollower(0, n.onHeartbeatReply)
 	if !ret {
 		t.Error("replicateLogsTo should replicate logs but it didn't")
 	}
@@ -305,7 +305,7 @@ func TestReplicateToFollower(t *testing.T) {
 	logMgr.snapshotTerm = 2
 	logMgr.lastSnapshotFile = "snapshot"
 	peer0.nextIndex = 3
-	ret = n.replicateToFollower(0)
+	ret = n.replicateToFollower(0, n.onHeartbeatReply)
 	if !ret {
 		t.Error("replicateLogsTo should replicate snapshot but it didn't")
 	}
@@ -324,7 +324,7 @@ func TestReplicateToFollower(t *testing.T) {
 	logMgr.snapshotTerm = 2
 	logMgr.lastSnapshotFile = "snapshotsmaller"
 	peer0.nextIndex = 2
-	ret = n.replicateToFollower(0)
+	ret = n.replicateToFollower(0, n.onHeartbeatReply)
 	if !ret {
 		t.Error("replicateLogsTo should replicate snapshot but it didn't")
 	}

--- a/pkg/raft/peermanager.go
+++ b/pkg/raft/peermanager.go
@@ -129,11 +129,11 @@ func (mgr *PeerManager) UpdateFollowerMatchIndex(nodeID int, matched bool, lastM
 	peer := mgr.GetPeer(nodeID)
 
 	if matched {
-		util.WriteTrace("Updating Node%d nextIndex. lastMatch %d", nodeID, lastMatch)
+		util.WriteVerbose("Updating Node%d's nextIndex. lastMatch %d", nodeID, lastMatch)
 		peer.nextIndex = lastMatch + 1
 		peer.matchIndex = lastMatch
 	} else {
-		util.WriteTrace("Decreasing Node%d nextIndex.", nodeID)
+		util.WriteVerbose("Decreasing Node%d's nextIndex.", nodeID)
 		// prev entries don't match. decrement nextIndex.
 		// cap it to 0. It is meaningless when less than zero
 		peer.nextIndex = util.Max(0, peer.nextIndex-nextIndexFallbackStep)
@@ -166,7 +166,7 @@ func (mgr *PeerManager) AppendEntries(nodeID int, req *AppendEntriesRequest, onR
 		reply, err := peer.proxy.AppendEntries(req)
 
 		if err != nil {
-			util.WriteTrace("AppendEntry call failed to Node%d", nodeID)
+			util.WriteTrace("AppendEntry call failed to Node%d: %s", nodeID, err)
 			reply = nil
 		}
 
@@ -182,7 +182,7 @@ func (mgr *PeerManager) InstallSnapshot(nodeID int, req *SnapshotRequest, onRepl
 		reply, err := peer.proxy.InstallSnapshot(req)
 
 		if err != nil {
-			util.WriteTrace("InstallSnapshot call failed to Node%d", nodeID)
+			util.WriteTrace("InstallSnapshot call failed to Node%d: %s", nodeID, err)
 			reply = nil
 		}
 
@@ -197,7 +197,7 @@ func (mgr *PeerManager) RequestVote(nodeID int, req *RequestVoteRequest, onReply
 		reply, err := peer.proxy.RequestVote(req)
 
 		if err != nil {
-			util.WriteTrace("RequestVote call failed to Node%d", nodeID)
+			util.WriteTrace("RequestVote call failed to Node%d: %s", nodeID, err)
 			reply = nil
 		}
 

--- a/pkg/raft/peermanager_test.go
+++ b/pkg/raft/peermanager_test.go
@@ -9,17 +9,26 @@ import (
 // PeerProxy mock
 type PeerProxyMock struct {
 	nodeID int
-	aec    chan *AppendEntriesRequest
-	isc    chan *SnapshotRequest
 }
 
 func (proxy *PeerProxyMock) AppendEntries(req *AppendEntriesRequest, callback func(*AppendEntriesReply)) {
-	proxy.aec <- req
+	callback(&AppendEntriesReply{
+		NodeID:    proxy.nodeID,
+		Term:      req.Term,
+		LastMatch: req.PrevLogIndex + len(req.Entries),
+		Success:   true,
+	})
 }
 func (proxy *PeerProxyMock) RequestVote(req *RequestVoteRequest, callback func(*RequestVoteReply)) {
+	callback(nil)
 }
 func (proxy *PeerProxyMock) InstallSnapshot(req *SnapshotRequest, callback func(*AppendEntriesReply)) {
-	proxy.isc <- req
+	callback(&AppendEntriesReply{
+		NodeID:    proxy.nodeID,
+		Term:      req.Term,
+		LastMatch: req.SnapshotIndex,
+		Success:   true,
+	})
 }
 func (proxy *PeerProxyMock) Get(req *GetRequest) (*GetReply, error) {
 	return nil, nil
@@ -28,22 +37,12 @@ func (proxy *PeerProxyMock) Execute(cmd *StateMachineCmd) (*ExecuteReply, error)
 	return nil, nil
 }
 
-func (proxy *PeerProxyMock) expectAECall() *AppendEntriesRequest {
-	return <-proxy.aec
-}
-
-func (proxy *PeerProxyMock) expectISCall() *SnapshotRequest {
-	return <-proxy.isc
-}
-
 // PeerFactory mock
 type PeerFactoryMock struct{}
 
 func (f *PeerFactoryMock) NewPeerProxy(info NodeInfo) IPeerProxy {
 	return &PeerProxyMock{
 		nodeID: info.NodeID,
-		aec:    make(chan *AppendEntriesRequest),
-		isc:    make(chan *SnapshotRequest),
 	}
 }
 

--- a/pkg/raft/peermanager_test.go
+++ b/pkg/raft/peermanager_test.go
@@ -11,24 +11,24 @@ type PeerProxyMock struct {
 	nodeID int
 }
 
-func (proxy *PeerProxyMock) AppendEntries(req *AppendEntriesRequest, callback func(*AppendEntriesReply)) {
-	callback(&AppendEntriesReply{
+func (proxy *PeerProxyMock) AppendEntries(req *AppendEntriesRequest) (*AppendEntriesReply, error) {
+	return &AppendEntriesReply{
 		NodeID:    proxy.nodeID,
 		Term:      req.Term,
 		LastMatch: req.PrevLogIndex + len(req.Entries),
 		Success:   true,
-	})
+	}, nil
 }
-func (proxy *PeerProxyMock) RequestVote(req *RequestVoteRequest, callback func(*RequestVoteReply)) {
-	callback(nil)
+func (proxy *PeerProxyMock) RequestVote(req *RequestVoteRequest) (*RequestVoteReply, error) {
+	return nil, nil
 }
-func (proxy *PeerProxyMock) InstallSnapshot(req *SnapshotRequest, callback func(*AppendEntriesReply)) {
-	callback(&AppendEntriesReply{
+func (proxy *PeerProxyMock) InstallSnapshot(req *SnapshotRequest) (*AppendEntriesReply, error) {
+	return &AppendEntriesReply{
 		NodeID:    proxy.nodeID,
 		Term:      req.Term,
 		LastMatch: req.SnapshotIndex,
 		Success:   true,
-	})
+	}, nil
 }
 func (proxy *PeerProxyMock) Get(req *GetRequest) (*GetReply, error) {
 	return nil, nil

--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -10,8 +10,10 @@ const (
 	LevelWarning = 2
 	// LevelInfo, warning and error
 	LevelInfo = 3
-	// All
+	// Info, warning, error and trace
 	LevelTrace = 4
+	// All
+	LevelVerbose = 5
 )
 
 // raft logger and log level
@@ -22,9 +24,6 @@ var logLevel = LevelInfo
 func SetLogLevel(level int) {
 	if level < LevelError {
 		level = LevelError
-	}
-	if level > LevelTrace {
-		level = LevelTrace
 	}
 
 	logLevel = level
@@ -55,6 +54,11 @@ func WriteInfo(format string, v ...interface{}) {
 // WriteTrace writes traces and debug information
 func WriteTrace(format string, v ...interface{}) {
 	WriteLog(LevelTrace, format, v...)
+}
+
+// WriteVerbose writes verbose infromation
+func WriteVerbose(format string, v ...interface{}) {
+	WriteLog(LevelVerbose, format, v...)
 }
 
 // Panicf is equivalent to l.Printf() followed by a call to panic().


### PR DESCRIPTION
Now execution (Set/Delete) will replicate new entry to all followers and wait for consensus before returning to client. This makes us act in the same way described by the raft paper.